### PR TITLE
PF-1428 Creates a Flowsheet DataModel

### DIFF
--- a/lib/redox.rb
+++ b/lib/redox.rb
@@ -12,10 +12,13 @@ require_relative "redox/models/location"
 require_relative "redox/models/media"
 require_relative "redox/models/message"
 require_relative "redox/models/meta"
+require_relative "redox/models/observation"
+require_relative "redox/models/observer"
 require_relative "redox/models/patient_identifier"
 require_relative "redox/models/patient"
 require_relative "redox/models/phone_number"
 require_relative "redox/models/provider"
+require_relative "redox/models/reference_range"
 require_relative "redox/models/visit"
 
 require_relative "redox/source"
@@ -25,6 +28,7 @@ require_relative "redox/file_upload"
 require_relative "redox/patient_search/query.rb"
 require_relative "redox/scheduling/booked.rb"
 require_relative "redox/media/new.rb"
+require_relative "redox/flowsheet/new.rb"
 
 module Redox
   class Error < StandardError

--- a/lib/redox/flowsheet/new.rb
+++ b/lib/redox/flowsheet/new.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "redox"
+
+module Redox
+  module Flowsheet
+    class New < Models::Message
+      redox_property :Patient, coerce: Models::Patient
+      redox_property :Visit, coerce: Models::Visit
+      redox_property :Observations, coerce: Array[Models::Observation]
+    end
+  end
+end

--- a/lib/redox/models/observation.rb
+++ b/lib/redox/models/observation.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "observer"
+require_relative "reference_range"
+
+module Redox
+  module Models
+    class Observation < Redox::Model
+      redox_property :DateTime
+      redox_property :Value
+      redox_property :ValueType
+      redox_property :Units
+      redox_property :Code
+      redox_property :Codeset
+      redox_property :Description
+      redox_property :Status
+      redox_property :Notes, coerce: Array[String]
+      redox_property :Observer, coerce: Observer
+      redox_property :ReferenceRange, coerce: ReferenceRange
+      redox_property :AbnormalFlag
+    end
+  end
+end

--- a/lib/redox/models/observer.rb
+++ b/lib/redox/models/observer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Redox
+  module Models
+    class Observer < Redox::Model
+      redox_property :ID
+      redox_property :IDType
+      redox_property :FirstName
+      redox_property :LastName
+    end
+  end
+end

--- a/lib/redox/models/reference_range.rb
+++ b/lib/redox/models/reference_range.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Redox
+  module Models
+    class ReferenceRange < Redox::Model
+      redox_property :Low
+      redox_property :High
+      redox_property :Text
+    end
+  end
+end

--- a/spec/redox/flowsheet/new_spec.rb
+++ b/spec/redox/flowsheet/new_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+RSpec.describe Redox::Flowsheet::New do
+  it "supports redox json" do
+    flowsheet = Redox::Flowsheet::New.from_redox_json example_flowsheet
+    expect(flowsheet.meta.message.id).to eq 5565
+    expect(flowsheet.observations.first.value).to eq "110.00"
+  end
+end
+
+# Flowsheet example from Redox API docs
+def example_flowsheet
+  %(
+    {
+      "Meta": {
+        "DataModel": "Flowsheet",
+        "EventType": "New",
+        "EventDateTime": "2020-10-28T15:54:21.139Z",
+        "Test": true,
+        "Source": {
+          "ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
+          "Name": "Redox Dev Tools"
+        },
+        "Destinations": [
+          {
+            "ID": "af394f14-b34a-464f-8d24-895f370af4c9",
+            "Name": "Redox EMR"
+          }
+        ],
+        "Message": {
+          "ID": 5565
+        },
+        "Transmission": {
+          "ID": 12414
+        },
+        "FacilityCode": null
+      },
+      "Patient": {
+        "Identifiers": [
+          {
+            "ID": "0000000001",
+            "IDType": "MR"
+          },
+          {
+            "ID": "e167267c-16c9-4fe3-96ae-9cff5703e90a",
+            "IDType": "EHRID"
+          },
+          {
+            "ID": "a1d4ee8aba494ca",
+            "IDType": "NIST"
+          }
+        ],
+        "Demographics": {
+          "FirstName": "Timothy",
+          "MiddleName": "Paul",
+          "LastName": "Bixby",
+          "DOB": "2008-01-06",
+          "SSN": "101-01-0001",
+          "Sex": "Male",
+          "Race": "White",
+          "IsHispanic": null,
+          "MaritalStatus": "Married",
+          "IsDeceased": null,
+          "DeathDateTime": null,
+          "PhoneNumber": {
+            "Home": "+18088675301",
+            "Office": null,
+            "Mobile": null
+          },
+          "EmailAddresses": [],
+          "Language": "en",
+          "Citizenship": [],
+          "Address": {
+            "StreetAddress": "4762 Hickory Street",
+            "City": "Monroe",
+            "State": "WI",
+            "ZIP": "53566",
+            "County": "Green",
+            "Country": "US"
+          }
+        },
+        "Notes": [],
+        "Contacts": [
+          {
+            "FirstName": "Barbara",
+            "MiddleName": null,
+            "LastName": "Bixby",
+            "Address": {
+              "StreetAddress": "4762 Hickory Street",
+              "City": "Monroe",
+              "State": "WI",
+              "ZIP": "53566",
+              "County": "Green",
+              "Country": "US"
+            },
+            "PhoneNumber": {
+              "Home": "+18088675303",
+              "Office": "+17077543758",
+              "Mobile": "+19189368865"
+            },
+            "RelationToPatient": "Mother",
+            "EmailAddresses": [
+              "barb.bixby@test.net"
+            ],
+            "Roles": [
+              "Emergency Contact"
+            ]
+          }
+        ]
+      },
+      "Visit": {
+        "VisitNumber": "1234",
+        "AccountNumber": null,
+        "VisitDateTime": null,
+        "Location": {
+          "Type": null,
+          "Facility": null,
+          "Department": null,
+          "Room": null,
+          "Bed": null
+        }
+      },
+      "Observations": [
+        {
+          "DateTime": "2015-08-13T21:08:57.581Z",
+          "Value": "110.00",
+          "ValueType": "Numeric",
+          "Units": "mmHg",
+          "Code": "Systolic",
+          "Codeset": "RedoxEMR",
+          "Description": null,
+          "Status": null,
+          "Notes": [
+            "Observation note."
+          ],
+          "Observer": {
+            "ID": "12312",
+            "IDType": null,
+            "FirstName": "Jimmy",
+            "LastName": "JimJam"
+          },
+          "ReferenceRange": {
+            "Low": null,
+            "High": null,
+            "Text": null
+          },
+          "AbnormalFlag": null
+        },
+        {
+          "DateTime": "2015-08-13T21:08:57.581Z",
+          "Value": "90.00",
+          "ValueType": "Numeric",
+          "Units": "mmHg",
+          "Code": "Diastolic",
+          "Codeset": "RedoxEMR",
+          "Description": null,
+          "Status": null,
+          "Notes": [],
+          "Observer": {
+            "ID": "12312",
+            "IDType": null,
+            "FirstName": "Jimmy",
+            "LastName": "JimJam"
+          },
+          "ReferenceRange": {
+            "Low": null,
+            "High": null,
+            "Text": null
+          },
+          "AbnormalFlag": null
+        },
+        {
+          "DateTime": "2015-08-13T21:08:57.581Z",
+          "Value": "55",
+          "ValueType": "Numeric",
+          "Units": "beats/min",
+          "Code": "Diastolic",
+          "Codeset": "RedoxEMR",
+          "Description": null,
+          "Status": null,
+          "Notes": [],
+          "Observer": {
+            "ID": "12312",
+            "IDType": null,
+            "FirstName": "Jimmy",
+            "LastName": "JimJam"
+          },
+          "ReferenceRange": {
+            "Low": null,
+            "High": null,
+            "Text": null
+          },
+          "AbnormalFlag": null
+        }
+      ]
+    }
+  )
+end


### PR DESCRIPTION
**Description**
Creates a Flowsheet DataModel, creates new models for Observations, Observers, and ReferenceRanges as described in reference: https://developer.redoxengine.com/data-models/Flowsheet.html

**Tests**
Automatic: No automatic tests at this time.

Manual:
After opening the console using `bin/console`, a sample Flowsheet can be creating using the following code:

> flowsheet = Redox::Flowsheet::New.new(
> patient: Redox::Models::Patient.new(
> identifiers: [
> Redox::Models::PatientIdentifier.new(id_type: "MR", id: "42")
> ]
> ),
> visit: Redox::Models::Visit.new(visit_number: 42),
> observations: [
> Redox::Models::Observation.new(
> value: "FooBar",
> observer: Redox::Models::Observer.new(id: 000),
> reference_range: Redox::Models::ReferenceRange.new(low: 5, high: 10)
> )
> ]
> )